### PR TITLE
Apply @GhostRussia fix for non-null custom types

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -428,7 +428,7 @@ check:
 			if typ[len(typ)-1] != '*' {
 				typ = typ + "*"
 			}
-		} else {
+		} else if tp.Kind() != "SCALAR" {
 			typ = "*"
 		}
 		typ = typ + *name + "Resolver"


### PR DESCRIPTION
Per title, applying fix for non-null custom types.

Described in #1 .